### PR TITLE
Add the ability to reverse mousewheel scroll direction

### DIFF
--- a/README.reference
+++ b/README.reference
@@ -127,7 +127,7 @@ Variable names:
 				  "recenter-top-bottom" and "recenter" commands.
 				  Default 0.
 
-"reverse-mousewheel"            - Inicates if the scroll direction of the mouse wheel
+"reverse-mousewheel"            - Indicates if the scroll direction of the mouse wheel
 				  should be reversed. Helpful for certain terminals.
 				  Default is 0.
 

--- a/README.reference
+++ b/README.reference
@@ -127,6 +127,10 @@ Variable names:
 				  "recenter-top-bottom" and "recenter" commands.
 				  Default 0.
 
+"reverse-mousewheel"            - Inicates if the scroll direction of the mouse wheel
+				  should be reversed. Helpful for certain terminals.
+				  Default is 0.
+
 "modeline-show"			- A set of binary flags controlling what is showed in
 				  the modeline. Default is 0. Values to add together:
 

--- a/basic.c
+++ b/basic.c
@@ -605,6 +605,11 @@ gotoline(INT f, INT n)
 	return TRUE;
 }
 
+/*
+ * Mg3a: Set default for mousewheel direction
+ */
+INT reverse_mousewheel = 0;
+
 #ifdef MOUSE
 /*
  * Respond to mouse messages
@@ -627,7 +632,12 @@ mousemsg(INT f, INT n)
 	}
 #endif
 	if ((mreport[0] & 0xfe) == 0x60) {
-		return forwline(0, 1 - 2*(mreport[0] & 0x01));
+		/* Mg3a: make mousewheel reversable */
+		if (reverse_mousewheel == 0) {
+			return forwline(0, 1 - 2*(mreport[0] & 0x01));
+		} else {
+			return backline(0, 1 - 2*(mreport[0] & 0x01));			
+		}
 	} else if (mreport[0] == 0x20) {
 		INT x=mreport[1]-32, y=mreport[2]-32;
 		for (WINDOW *wp = wheadp; wp; wp = wp->w_wndp) {

--- a/basic.c
+++ b/basic.c
@@ -15,6 +15,7 @@ INT	backline(INT f, INT n);
 INT	backpage(INT f, INT n);
 INT	nextwind(INT f, INT n);
 INT	endvisualline(INT f, INT n);
+INT	reverse_mousewheel; /* Mg3a: mousewheel reverse direction; default is off */
 
 extern	INT	getkey(INT);		/* 	*/
 extern  INT     refresh(INT,INT);       /* window.c */
@@ -605,10 +606,6 @@ gotoline(INT f, INT n)
 	return TRUE;
 }
 
-/*
- * Mg3a: Set default for mousewheel direction
- */
-INT reverse_mousewheel = 0;
 
 #ifdef MOUSE
 /*
@@ -632,7 +629,7 @@ mousemsg(INT f, INT n)
 	}
 #endif
 	if ((mreport[0] & 0xfe) == 0x60) {
-		/* Mg3a: make mousewheel reversable */
+		/* Mg3a: toggle for wheel reverse */
 		if (reverse_mousewheel == 0) {
 			return forwline(0, 1 - 2*(mreport[0] & 0x01));
 		} else {

--- a/variables.c
+++ b/variables.c
@@ -18,6 +18,7 @@ extern INT makebackup;
 extern INT scrollbyone;
 extern INT recenter_redisplay;
 extern INT modeline_show;
+extern INT reverse_mousewheel;
 extern INT kill_whole_lines;
 extern INT quoted_char_radix;
 extern INT fill_options;
@@ -64,6 +65,7 @@ static const var_entry variables[] = {
 	{"",			0, NULL},
 	{"window-scroll", 	'i', &scrollbyone},
 	{"recenter-redisplay",'i', &recenter_redisplay},
+	{"reverse-mousewheel", 'i', &reverse_mousewheel},
 	{"",			0, NULL},
 	{"modeline-show",	'i', &modeline_show},
 	{"kill-whole-lines",	'i', &kill_whole_lines},


### PR DESCRIPTION
I first want to say that I really like this editor, and I've been coding on it daily for a while now. Thanks for maintaining it!

That said, the scroll direction being "natural" (i.e. reversed) is a bit of a nuisance (see also https://github.com/paaguti/mg3a/issues/6).

I added a variable to toggle the wheel direction and put an entry in the reference README.